### PR TITLE
SL-5978 Create escalation logger class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,6 @@
 
 * Initial release
 
-## 1.0.1 (May 2, 2023)
+## 1.1.0 (May 2, 2023)
 
 * Create EscalationLogger class to all for automatic escalation based off of log messages.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,7 @@
 ## 1.0.0 (Jan 1, 2014)
 
 * Initial release
+
+## 1.0.1 (May 2, 2023)
+
+* Create EscalationLogger class to all for automatic escalation based off of log messages.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ structured arguments to be included in `ch.qos.logback.classic.net.SyslogAppende
 <dependency>
   <groupId>com.echobox</groupId>
   <artifactId>ebx-structuredlogging-sdk</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ structured arguments to be included in `ch.qos.logback.classic.net.SyslogAppende
 <dependency>
   <groupId>com.echobox</groupId>
   <artifactId>ebx-structuredlogging-sdk</artifactId>
-  <version>1.0.1</version>
+  <version>1.1.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   
   <groupId>com.echobox</groupId>
   <artifactId>ebx-structuredlogging-sdk</artifactId>
-  <version>1.0.1</version>
+  <version>1.1.0</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,20 @@
       <artifactId>logstash-logback-encoder</artifactId>
       <version>6.4</version>
     </dependency>
+
+    <!-- Tests -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.9.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.2.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   
   <groupId>com.echobox</groupId>
   <artifactId>ebx-structuredlogging-sdk</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/src/main/java/com/echobox/logging/escalator/EscalationAction.java
+++ b/src/main/java/com/echobox/logging/escalator/EscalationAction.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.echobox.logging.escalator;
+
+/**
+ * Interface to do an escalation action once the desired trigger threshold has been met
+ *
+ * @author eddspencer
+ */
+public interface EscalationAction {
+  void escalate();
+}

--- a/src/main/java/com/echobox/logging/escalator/EscalationAction.java
+++ b/src/main/java/com/echobox/logging/escalator/EscalationAction.java
@@ -23,5 +23,11 @@ package com.echobox.logging.escalator;
  * @author eddspencer
  */
 public interface EscalationAction {
-  void escalate();
+  
+  /**
+   * An escalation has been triggered with the given keys
+   *
+   * @param keys the keys
+   */
+  void escalate(Object... keys);
 }

--- a/src/main/java/com/echobox/logging/escalator/EscalationLogger.java
+++ b/src/main/java/com/echobox/logging/escalator/EscalationLogger.java
@@ -43,7 +43,7 @@ public class EscalationLogger implements Logger {
   
   private <T> void checkForEscalation(LoggingLevel level, Object... keys) {
     if (trigger.markAndTrigger(level, keys)) {
-      action.escalate();
+      action.escalate(keys);
     }
   }
   

--- a/src/main/java/com/echobox/logging/escalator/EscalationLogger.java
+++ b/src/main/java/com/echobox/logging/escalator/EscalationLogger.java
@@ -1,0 +1,459 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.echobox.logging.escalator;
+
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+
+/**
+ * Logger wrapper that will escalate to another action if a certain trigger function passes on a
+ * logger. For example, if 10 debug messages of the same text are made within 10min an
+ * escalation could be made.
+ *
+ * N.B. the original message is still logged even when an escalation is made.
+ *
+ * @author eddspencer
+ */
+public class EscalationLogger implements Logger {
+  
+  private final Logger logger;
+  private final EscalationTrigger trigger;
+  private final EscalationAction action;
+  
+  public EscalationLogger(Logger logger, EscalationTrigger trigger, EscalationAction action) {
+    this.logger = logger;
+    this.trigger = trigger;
+    this.action = action;
+  }
+  
+  private <T> void checkForEscalation(LoggingLevel level, Object... keys) {
+    if (trigger.markAndTrigger(level, keys)) {
+      action.escalate();
+    }
+  }
+  
+  @Override
+  public String getName() {
+    return logger.getName();
+  }
+  
+  @Override
+  public boolean isTraceEnabled() {
+    return logger.isTraceEnabled();
+  }
+  
+  @Override
+  public boolean isTraceEnabled(Marker marker) {
+    return logger.isTraceEnabled(marker);
+  }
+  
+  @Override
+  public void trace(String msg) {
+    checkForEscalation(LoggingLevel.TRACE, msg);
+    
+    logger.trace(msg);
+  }
+  
+  @Override
+  public void trace(String format, Object arg) {
+    checkForEscalation(LoggingLevel.TRACE, format, arg);
+    
+    logger.trace(format, arg);
+  }
+  
+  @Override
+  public void trace(String format, Object arg1, Object arg2) {
+    checkForEscalation(LoggingLevel.TRACE, format, arg1, arg2);
+    
+    logger.trace(format, arg1, arg2);
+  }
+  
+  @Override
+  public void trace(String format, Object... arguments) {
+    checkForEscalation(LoggingLevel.TRACE, format, arguments);
+    
+    logger.trace(format, arguments);
+  }
+  
+  @Override
+  public void trace(String msg, Throwable throwable) {
+    checkForEscalation(LoggingLevel.TRACE, msg, throwable);
+    
+    logger.trace(msg, throwable);
+  }
+  
+  @Override
+  public void trace(Marker marker, String msg) {
+    checkForEscalation(LoggingLevel.TRACE, marker, msg);
+    
+    logger.trace(marker, msg);
+  }
+  
+  @Override
+  public void trace(Marker marker, String format, Object arg) {
+    checkForEscalation(LoggingLevel.TRACE, marker, format, arg);
+    
+    logger.trace(marker, format, arg);
+  }
+  
+  @Override
+  public void trace(Marker marker, String format, Object arg1, Object arg2) {
+    checkForEscalation(LoggingLevel.TRACE, marker, format, arg1, arg2);
+    
+    logger.trace(marker, format, arg1, arg2);
+  }
+  
+  @Override
+  public void trace(Marker marker, String format, Object... argArray) {
+    checkForEscalation(LoggingLevel.TRACE, marker, format, argArray);
+    
+    logger.trace(marker, format, argArray);
+  }
+  
+  @Override
+  public void trace(Marker marker, String msg, Throwable throwable) {
+    checkForEscalation(LoggingLevel.TRACE, marker, msg, throwable);
+    
+    logger.trace(marker, msg, throwable);
+  }
+  
+  @Override
+  public boolean isDebugEnabled() {
+    return logger.isDebugEnabled();
+  }
+  
+  @Override
+  public boolean isDebugEnabled(Marker marker) {
+    return logger.isDebugEnabled(marker);
+  }
+  
+  @Override
+  public void debug(String msg) {
+    checkForEscalation(LoggingLevel.DEBUG, msg);
+    
+    logger.debug(msg);
+  }
+  
+  @Override
+  public void debug(String format, Object arg) {
+    checkForEscalation(LoggingLevel.DEBUG, format, arg);
+    
+    logger.debug(format, arg);
+  }
+  
+  @Override
+  public void debug(String format, Object arg1, Object arg2) {
+    checkForEscalation(LoggingLevel.DEBUG, format, arg1, arg2);
+    
+    logger.debug(format, arg1, arg2);
+  }
+  
+  @Override
+  public void debug(String format, Object... arguments) {
+    checkForEscalation(LoggingLevel.DEBUG, format, arguments);
+    
+    logger.debug(format, arguments);
+  }
+  
+  @Override
+  public void debug(String msg, Throwable throwable) {
+    checkForEscalation(LoggingLevel.DEBUG, msg, throwable);
+    
+    logger.debug(msg, throwable);
+  }
+  
+  @Override
+  public void debug(Marker marker, String msg) {
+    checkForEscalation(LoggingLevel.DEBUG, marker, msg);
+    
+    logger.debug(marker, msg);
+  }
+  
+  @Override
+  public void debug(Marker marker, String format, Object arg) {
+    checkForEscalation(LoggingLevel.DEBUG, marker, format, arg);
+    
+    logger.debug(marker, format, arg);
+  }
+  
+  @Override
+  public void debug(Marker marker, String format, Object arg1, Object arg2) {
+    checkForEscalation(LoggingLevel.DEBUG, marker, arg1, arg2);
+    
+    logger.debug(marker, format, arg1, arg2);
+  }
+  
+  @Override
+  public void debug(Marker marker, String format, Object... arguments) {
+    checkForEscalation(LoggingLevel.DEBUG, marker, format, arguments);
+    
+    logger.debug(marker, format, arguments);
+  }
+  
+  @Override
+  public void debug(Marker marker, String msg, Throwable throwable) {
+    checkForEscalation(LoggingLevel.DEBUG, marker, msg, throwable);
+    
+    logger.debug(marker, msg, throwable);
+  }
+  
+  @Override
+  public boolean isInfoEnabled() {
+    return logger.isInfoEnabled();
+  }
+  
+  @Override
+  public boolean isInfoEnabled(Marker marker) {
+    checkForEscalation(LoggingLevel.INFO, marker);
+    
+    return logger.isInfoEnabled(marker);
+  }
+  
+  @Override
+  public void info(String msg) {
+    checkForEscalation(LoggingLevel.INFO, msg);
+    
+    logger.info(msg);
+  }
+  
+  @Override
+  public void info(String format, Object arg) {
+    checkForEscalation(LoggingLevel.INFO, format, arg);
+    
+    logger.info(format, arg);
+  }
+  
+  @Override
+  public void info(String format, Object arg1, Object arg2) {
+    checkForEscalation(LoggingLevel.INFO, arg1, arg2);
+    
+    logger.info(format, arg1, arg2);
+  }
+  
+  @Override
+  public void info(String format, Object... arguments) {
+    checkForEscalation(LoggingLevel.INFO, format, arguments);
+    
+    logger.info(format, arguments);
+  }
+  
+  @Override
+  public void info(String msg, Throwable throwable) {
+    checkForEscalation(LoggingLevel.INFO, msg, throwable);
+    
+    logger.info(msg, throwable);
+  }
+  
+  @Override
+  public void info(Marker marker, String msg) {
+    checkForEscalation(LoggingLevel.INFO, marker, msg);
+    
+    logger.info(marker, msg);
+  }
+  
+  @Override
+  public void info(Marker marker, String format, Object arg) {
+    checkForEscalation(LoggingLevel.INFO, marker, arg);
+    
+    logger.info(marker, format, arg);
+  }
+  
+  @Override
+  public void info(Marker marker, String format, Object arg1, Object arg2) {
+    checkForEscalation(LoggingLevel.INFO, marker, arg1, arg2);
+    
+    logger.info(marker, format, arg1, arg2);
+  }
+  
+  @Override
+  public void info(Marker marker, String format, Object... arguments) {
+    checkForEscalation(LoggingLevel.INFO, marker, format, arguments);
+    
+    logger.info(marker, format, arguments);
+  }
+  
+  @Override
+  public void info(Marker marker, String msg, Throwable throwable) {
+    checkForEscalation(LoggingLevel.INFO, marker, msg, throwable);
+    
+    logger.info(marker, msg, throwable);
+  }
+  
+  @Override
+  public boolean isWarnEnabled() {
+    return logger.isWarnEnabled();
+  }
+  
+  @Override
+  public boolean isWarnEnabled(Marker marker) {
+    return logger.isWarnEnabled(marker);
+  }
+  
+  @Override
+  public void warn(String msg) {
+    checkForEscalation(LoggingLevel.WARN, msg);
+    
+    logger.warn(msg);
+  }
+  
+  @Override
+  public void warn(String format, Object arg) {
+    checkForEscalation(LoggingLevel.WARN, format, arg);
+    
+    logger.warn(format, arg);
+  }
+  
+  @Override
+  public void warn(String format, Object... arguments) {
+    checkForEscalation(LoggingLevel.WARN, format, arguments);
+    
+    logger.warn(format, arguments);
+  }
+  
+  @Override
+  public void warn(String format, Object arg1, Object arg2) {
+    checkForEscalation(LoggingLevel.WARN, format, arg1, arg2);
+    
+    logger.warn(format, arg1, arg2);
+  }
+  
+  @Override
+  public void warn(String msg, Throwable throwable) {
+    checkForEscalation(LoggingLevel.WARN, msg, throwable);
+    
+    logger.warn(msg, throwable);
+  }
+  
+  @Override
+  public void warn(Marker marker, String msg) {
+    checkForEscalation(LoggingLevel.WARN, marker, msg);
+    
+    logger.warn(marker, msg);
+  }
+  
+  @Override
+  public void warn(Marker marker, String format, Object arg) {
+    checkForEscalation(LoggingLevel.WARN, marker, format, arg);
+    
+    logger.warn(marker, format, arg);
+  }
+  
+  @Override
+  public void warn(Marker marker, String format, Object arg1, Object arg2) {
+    checkForEscalation(LoggingLevel.WARN, marker, format, arg1, arg2);
+    
+    logger.warn(marker, format, arg1, arg2);
+  }
+  
+  @Override
+  public void warn(Marker marker, String format, Object... arguments) {
+    checkForEscalation(LoggingLevel.WARN, marker, format, arguments);
+    
+    logger.warn(marker, format, arguments);
+  }
+  
+  @Override
+  public void warn(Marker marker, String msg, Throwable throwable) {
+    checkForEscalation(LoggingLevel.WARN, marker, msg, throwable);
+    
+    logger.warn(marker, msg, throwable);
+  }
+  
+  @Override
+  public boolean isErrorEnabled() {
+    return logger.isErrorEnabled();
+  }
+  
+  @Override
+  public boolean isErrorEnabled(Marker marker) {
+    checkForEscalation(LoggingLevel.ERROR, marker);
+    
+    return logger.isErrorEnabled(marker);
+  }
+  
+  @Override
+  public void error(String msg) {
+    checkForEscalation(LoggingLevel.ERROR, msg);
+    
+    logger.error(msg);
+  }
+  
+  @Override
+  public void error(String format, Object arg) {
+    checkForEscalation(LoggingLevel.ERROR, format, arg);
+    
+    logger.error(format, arg);
+  }
+  
+  @Override
+  public void error(String format, Object arg1, Object arg2) {
+    checkForEscalation(LoggingLevel.ERROR, format, arg1, arg2);
+    
+    logger.error(format, arg1, arg2);
+  }
+  
+  @Override
+  public void error(String format, Object... arguments) {
+    checkForEscalation(LoggingLevel.ERROR, format, arguments);
+    
+    logger.error(format, arguments);
+  }
+  
+  @Override
+  public void error(String msg, Throwable throwable) {
+    checkForEscalation(LoggingLevel.ERROR, msg, throwable);
+    
+    logger.error(msg, throwable);
+  }
+  
+  @Override
+  public void error(Marker marker, String msg) {
+    checkForEscalation(LoggingLevel.ERROR, marker, msg);
+    
+    logger.error(marker, msg);
+  }
+  
+  @Override
+  public void error(Marker marker, String format, Object arg) {
+    checkForEscalation(LoggingLevel.ERROR, marker, format, arg);
+    
+    logger.error(marker, format, arg);
+  }
+  
+  @Override
+  public void error(Marker marker, String format, Object arg1, Object arg2) {
+    checkForEscalation(LoggingLevel.ERROR, marker, format, arg1, arg2);
+    
+    logger.error(marker, format, arg1, arg2);
+  }
+  
+  @Override
+  public void error(Marker marker, String format, Object... arguments) {
+    checkForEscalation(LoggingLevel.ERROR, marker, format, arguments);
+    
+    logger.error(marker, format, arguments);
+  }
+  
+  @Override
+  public void error(Marker marker, String msg, Throwable throwable) {
+    checkForEscalation(LoggingLevel.ERROR, marker, msg, throwable);
+    
+    logger.error(marker, msg, throwable);
+  }
+  
+}

--- a/src/main/java/com/echobox/logging/escalator/EscalationLogger.java
+++ b/src/main/java/com/echobox/logging/escalator/EscalationLogger.java
@@ -219,8 +219,6 @@ public class EscalationLogger implements Logger {
   
   @Override
   public boolean isInfoEnabled(Marker marker) {
-    checkForEscalation(LoggingLevel.INFO, marker);
-    
     return logger.isInfoEnabled(marker);
   }
   
@@ -381,8 +379,6 @@ public class EscalationLogger implements Logger {
   
   @Override
   public boolean isErrorEnabled(Marker marker) {
-    checkForEscalation(LoggingLevel.ERROR, marker);
-    
     return logger.isErrorEnabled(marker);
   }
   

--- a/src/main/java/com/echobox/logging/escalator/EscalationTrigger.java
+++ b/src/main/java/com/echobox/logging/escalator/EscalationTrigger.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.echobox.logging.escalator;
+
+/**
+ * Interface to mark an event and return if this should result in an escalation
+ *
+ * @author eddspencer
+ */
+public interface EscalationTrigger {
+  boolean markAndTrigger(LoggingLevel level, Object... keys);
+}

--- a/src/main/java/com/echobox/logging/escalator/EscalationTrigger.java
+++ b/src/main/java/com/echobox/logging/escalator/EscalationTrigger.java
@@ -23,5 +23,12 @@ package com.echobox.logging.escalator;
  * @author eddspencer
  */
 public interface EscalationTrigger {
+  /**
+   * Mark the logging event for the given keys and check if escalation is triggered
+   *
+   * @param level the level
+   * @param keys the keys
+   * @return whether to trigger and escalation
+   */
   boolean markAndTrigger(LoggingLevel level, Object... keys);
 }

--- a/src/main/java/com/echobox/logging/escalator/LoggingLevel.java
+++ b/src/main/java/com/echobox/logging/escalator/LoggingLevel.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.echobox.logging.escalator;
+
+/**
+ * Logging levels to use in tracking events
+ *
+ * @author eddspencer
+ */
+enum LoggingLevel {
+  /**
+   * TRACE logging level
+   */
+  TRACE,
+  /**
+   * DEBUG logging level
+   */
+  DEBUG,
+  /**
+   * INFO logging level
+   */
+  INFO,
+  /**
+   * WARN logging level
+   */
+  WARN,
+  /**
+   * ERROR logging level
+   */
+  ERROR;
+}

--- a/src/main/test/com/echobox/logging/escalator/EscalationLoggerTest.java
+++ b/src/main/test/com/echobox/logging/escalator/EscalationLoggerTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.echobox.logging.escalator;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+
+class EscalationLoggerTest {
+  
+  private EscalationTrigger trigger;
+  private EscalationAction action;
+  private EscalationLogger escalationLogger;
+  
+  @BeforeEach
+  public void setup() {
+    trigger = Mockito.mock(EscalationTrigger.class);
+    action = Mockito.mock(EscalationAction.class);
+    
+    final Logger logger = Mockito.mock(Logger.class);
+    escalationLogger = new EscalationLogger(logger, trigger, action);
+  }
+  
+  @Test
+  public void notEscalateButTriggered() {
+    escalationLogger.debug("This is a test");
+    
+    verify(action, times(0)).escalate();
+  }
+  
+  @Test
+  public void escalateTRACE() {
+    when(trigger.markAndTrigger(LoggingLevel.TRACE, "This is a {}", "test")).thenReturn(true);
+    
+    escalationLogger.trace("This is a {}", "test");
+    
+    verify(action).escalate();
+  }
+  
+  @Test
+  public void escalateDEBUG() {
+    when(trigger.markAndTrigger(LoggingLevel.DEBUG, "This is a test")).thenReturn(true);
+  
+    escalationLogger.debug("This is a test");
+    
+    verify(action).escalate();
+  }
+  
+  @Test
+  public void escalateINFO() {
+    when(trigger.markAndTrigger(LoggingLevel.INFO, "This is a test")).thenReturn(true);
+    
+    escalationLogger.info("This is a test");
+    
+    verify(action).escalate();
+  }
+  
+  @Test
+  public void escalateWARN() {
+    when(trigger.markAndTrigger(LoggingLevel.WARN, "This is a test")).thenReturn(true);
+    
+    escalationLogger.warn("This is a test");
+    
+    verify(action).escalate();
+  }
+  
+  @Test
+  public void escalateERROR() {
+    Exception error = new Exception("Error");
+    when(trigger.markAndTrigger(LoggingLevel.ERROR, "This is a test", error)).thenReturn(true);
+  
+    escalationLogger.error("This is a test", error);
+  
+    verify(action).escalate();
+  }
+  
+}

--- a/src/main/test/com/echobox/logging/escalator/EscalationLoggerTest.java
+++ b/src/main/test/com/echobox/logging/escalator/EscalationLoggerTest.java
@@ -45,7 +45,7 @@ class EscalationLoggerTest {
   public void notEscalateButTriggered() {
     escalationLogger.debug("This is a test");
     
-    verify(action, times(0)).escalate();
+    verify(action, times(0)).escalate("This is a test");
   }
   
   @Test
@@ -54,7 +54,7 @@ class EscalationLoggerTest {
     
     escalationLogger.trace("This is a {}", "test");
     
-    verify(action).escalate();
+    verify(action).escalate("This is a {}", "test");
   }
   
   @Test
@@ -63,7 +63,7 @@ class EscalationLoggerTest {
   
     escalationLogger.debug("This is a test");
     
-    verify(action).escalate();
+    verify(action).escalate("This is a test");
   }
   
   @Test
@@ -72,7 +72,7 @@ class EscalationLoggerTest {
     
     escalationLogger.info("This is a test");
     
-    verify(action).escalate();
+    verify(action).escalate("This is a test");
   }
   
   @Test
@@ -81,7 +81,7 @@ class EscalationLoggerTest {
     
     escalationLogger.warn("This is a test");
     
-    verify(action).escalate();
+    verify(action).escalate("This is a test");
   }
   
   @Test
@@ -91,7 +91,7 @@ class EscalationLoggerTest {
   
     escalationLogger.error("This is a test", error);
   
-    verify(action).escalate();
+    verify(action).escalate("This is a test", error);
   }
   
 }


### PR DESCRIPTION
### Description of Changes

Create a new class that extends `Logger` so that we can easily add escalation options to our logs. This PR includes the basic structure and examples with mocks in tests - if this is agreed will make some helpful implementations of the trigger and action interfaces as well in a separate PR.

### Documentation

N/A

### Risks & Impacts

Low risk this is adding new functionality

### Testing
Added unit tests.

## Final Checklist

Please tick once completed.

- [x] Build passes.
- [x] Versioning considered (the version number in this PR is inline with semantic 
versioning requirements).
- [x] Change log has been updated.